### PR TITLE
Update init.pp - Treat i386 as i586

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,7 +87,7 @@ class oracle_java (
   # translate system architecture to expected value
   case $::architecture {
     /x86_64|amd64/ : { $arch = 'x64' }
-    'x86'          : { $arch = 'i586' }
+    'x86|i386'          : { $arch = 'i586' }
     default        : { fail("oracle_java does not support architecture ${::architecture} (yet)") }
   }
 


### PR DESCRIPTION
Treat i386 as i586

On Ubuntu 16.04 facter returns:
architecture => i386
